### PR TITLE
Corrected typo `valut` to `vault` seen at `Handle all attachments`

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -609,7 +609,7 @@ class SettingTab extends PluginSettingTab {
 			.setName('Handle all attachments')
 			.setDesc(`By default, the plugin only handles images that starts with "Pasted image " in name,
 			which is the prefix Obsidian uses to create images from pasted content.
-			If this option is set, the plugin will handle all attachments that are created in the valut.`)
+			If this option is set, the plugin will handle all attachments that are created in the vault.`)
 			.addToggle(toggle => toggle
 				.setValue(this.plugin.settings.handleAllAttachments)
 				.onChange(async (value) => {


### PR DESCRIPTION
# Issue

![typo](https://user-images.githubusercontent.com/61069122/175941010-9ac4234c-c61c-4b43-9721-19e7a43856e4.png)

## Solution

Solved by correcting typo at the Setting container of Handle all attachments at `/src/main.ts`
