### PR TITLE
Unicode characters in name, resolves #30, #28, #9

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -67,7 +67,7 @@ export const path = {
 	},
 }
 
-const filenameNotAllowedChars = /[^a-zA-Z0-9~`!@$&*()\-_=+{};'",<.>? ]/g
+const filenameNotAllowedChars = /[^\p{L}0-9~`!@$&*()\-_=+{};'",<.>? ]/ug
 
 export const sanitizer = {
 	filename(s: string): string {


### PR DESCRIPTION
Fixes unicode characters in filename, resolves #30, #28, #9. 
Uses unicode category _\p{L} or \p{Letter}_: any kind of letter from any language.
more https://www.regular-expressions.info/unicode.html#category