### PR TITLE
Fix #49

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Obsidian paste image rename
 
+> Forked from `reorx/obsidian-paste-image-rename`. Fixed a bug, which may throw an error when target folder does not exist.
+
+---------
+
 > :loudspeaker: Starting from 1.4.0, Paste image rename becomes a general-purpose renaming plugin
 > that can handle all attachments added to the vault.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "obsidian-paste-image-rename",
 	"name": "Paste image rename",
-	"version": "1.6.1",
+	"version": "1.6.2",
 	"minAppVersion": "0.12.0",
 	"description": "Rename pasted images and all the other attchments added to the vault",
 	"author": "Reorx",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-paste-image-rename",
-	"version": "1.5.0",
+	"version": "1.6.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-paste-image-rename",
-			"version": "1.5.0",
+			"version": "1.6.1",
 			"license": "MIT",
 			"dependencies": {
 				"cash-dom": "^8.1.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-paste-image-rename",
-	"version": "1.6.1",
+	"version": "1.6.2",
 	"main": "main.js",
 	"scripts": {
 		"start": "node esbuild.config.mjs",

--- a/src/main.ts
+++ b/src/main.ts
@@ -158,6 +158,12 @@ export default class PasteImageRenamePlugin extends Plugin {
 
 		// file system operation: rename the file
 		const newPath = path.join(file.parent.path, newName)
+		const dirPath = path.dirname(newPath)
+
+		if (dirPath && !await this.app.vault.adapter.exists(dirPath)) {
+			await this.app.vault.createFolder(dirPath)
+		}
+
 		try {
 			await this.app.fileManager.renameFile(file, newPath)
 		} catch (err) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -69,6 +69,12 @@ export const path = {
 		const positions = [...fullpath.matchAll(new RegExp('\\.', 'gi'))].map(a => a.index)
 		return fullpath.slice(positions[positions.length - 1] + 1)
 	},
+
+	// return directory name of the path
+	dirname(fullpath: string): string {
+		const index = fullpath.lastIndexOf('/')
+		return fullpath.substring(0, index + 1)
+	}
 }
 
 const filenameNotAllowedChars = /[^\p{L}0-9~`!@$&*()\-_=+{};'",<.>? ]/ug


### PR DESCRIPTION
Solved #49 

- fix error when `/` in new file path (e.g. `note.assets/image.png`) and target folder (`note.assets` in this case) doesn't exist