### PR TITLE
Add template variable {{dirPath}}

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,16 +10,17 @@
  * - [ ] add rules for moving matched images to destination folder
  */
 import {
-	App,
-	HeadingCache, ListedFiles,
-	MarkdownView,
-	Modal,
-	Notice,
-	Plugin,
-	PluginSettingTab,
-	Setting,
-	TAbstractFile,
-	TFile,
+  App,
+  HeadingCache,
+  ListedFiles,
+  MarkdownView,
+  Modal,
+  Notice,
+  Plugin,
+  PluginSettingTab,
+  Setting,
+  TAbstractFile,
+  TFile,
 } from 'obsidian';
 
 import { ImageBatchRenameModal } from './batch';

--- a/src/template.ts
+++ b/src/template.ts
@@ -20,6 +20,7 @@ interface TemplateData {
 	imageNameKey: string
 	fileName: string
 	dirName: string
+	dirPath: string
 	firstHeading: string
 }
 
@@ -38,6 +39,7 @@ export const renderTemplate = (tmpl: string, data: TemplateData, frontmatter?: F
 		.replace(/{{imageNameKey}}/gm, data.imageNameKey)
 		.replace(/{{fileName}}/gm, data.fileName)
 		.replace(/{{dirName}}/gm, data.dirName)
+		.replace(/{{dirPath}}/gm, data.dirPath)
 		.replace(/{{firstHeading}}/gm, data.firstHeading)
 	return text
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import {
   App,
   Vault,
+  TFolder,
 } from 'obsidian';
 
 export const DEBUG = !(process.env.BUILD_ENV === 'production')
@@ -64,11 +65,32 @@ export const path = {
 		return sp[sp.length - 1]
 	},
 
+	/**
+	 * get the parent directory part of a file or directory
+	 * @param fullpath - full path of a file or directory
+	 * @returns the directory part of a path,
+	 * @example
+	 */
+	directory(fullpath: string): string {
+		const sp = fullpath.split('/')
+		return sp.slice(0, sp.length - 1).join('/')
+	},
+
 	// return extension without dot, e.g. 'jpg'
 	extension(fullpath: string): string {
 		const positions = [...fullpath.matchAll(new RegExp('\\.', 'gi'))].map(a => a.index)
 		return fullpath.slice(positions[positions.length - 1] + 1)
 	},
+}
+
+/**
+ * get the full path of given folder object
+ * @param tFolder - a folder object
+ * @returns the full path of directory
+ */
+export const getDirectoryPath = (tFolder: TFolder): string => {
+	if (tFolder.parent.name === '') return tFolder.name
+	return `${getDirectoryPath(tFolder.parent)}/${tFolder.name}`
 }
 
 const filenameNotAllowedChars = /[^\p{L}0-9~`!@$&*()\-_=+{};'",<.>? ]/ug


### PR DESCRIPTION
# Relates to
#60
#83 

# Why I tried this
It was difficult to manage all the files in one directory.
<img width="255" alt="image" src="https://github.com/reorx/obsidian-paste-image-rename/assets/122881432/14867af3-36a1-4fb6-8f23-b8836a49efcb">

# Screenshot
So I tried adding template variable called `{{dirPath}}`. When applied, it operates as follows.
![Jan-20-2024 21-13-46](https://github.com/reorx/obsidian-paste-image-rename/assets/122881432/817f041e-1719-4b04-8e94-b8a1ae81262f)


