### PR TITLE
Fix not updated links on multiple file insert when AutoRename is enabled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-paste-image-rename",
-	"version": "1.5.0",
+	"version": "1.6.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-paste-image-rename",
-			"version": "1.5.0",
+			"version": "1.6.1",
 			"license": "MIT",
 			"dependencies": {
 				"cash-dom": "^8.1.2"


### PR DESCRIPTION
I use this plugin with "AutoRename" and "Handle all attachments" on. It works great so far, thanks a lot for it. 

However, when I drag and drop multiple files at once in a note, the files were renamed correctly, but the links in the target note weren't updated but the last. This was seemingly due to the asynchronous behaviour of the functions: When the renameFile function fetched the cursor, it was already on a new position behind another inserted link due to the batch insert. Thus, it was not possible to locate and replace the link. 

Getting the cursor on time of the event trigger fixed it for me.